### PR TITLE
UI_v1 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ vosk*
 
 external-libs
 
-scratch_pad.kt
+scratch_pad.*
+scratch_pad
 BloodCellsExample.kt

--- a/src/main/kotlin/graphics/scenery/corvo/AnnotationsIngest.kt
+++ b/src/main/kotlin/graphics/scenery/corvo/AnnotationsIngest.kt
@@ -4,7 +4,6 @@ import ch.systemsx.cisd.base.mdarray.MDFloatArray
 import ch.systemsx.cisd.base.mdarray.MDIntArray
 import ch.systemsx.cisd.hdf5.HDF5Factory
 import ch.systemsx.cisd.hdf5.IHDF5Reader
-import graphics.scenery.backends.Renderer.Companion.logger
 import graphics.scenery.numerics.Random
 import graphics.scenery.utils.LazyLogger
 import hdf.hdf5lib.exceptions.HDF5SymbolTableException
@@ -19,7 +18,8 @@ class AnnotationsIngest(h5adPath: String) {
     val logger by LazyLogger()
     val reader: IHDF5Reader = HDF5Factory.openForReading(h5adPath)
 
-    val geneNames = h5adAnnotationReader("/var/feature_name/categories") //not robust, create UI selector
+    val feature_name = h5adAnnotationReader("/var/feature_name/categories") //not robust, create UI selector
+    val feature_id = h5adAnnotationReader("/var/feature_id")
 
     private val cscData: MDFloatArray = reader.float32().readMDArray("/X/data")
     private val cscIndices: MDIntArray = reader.int32().readMDArray("/X/indices")
@@ -68,29 +68,20 @@ class AnnotationsIngest(h5adPath: String) {
             }
         }
 
-        println(nonZeroGenes.size)
-        println(numGenes)
-
         for (obs in annotationList) {
             nCatList.add(h5adAnnotationReader("/obs/$obs/categories").size)  // still add as 1 indicates no gene info
             try  {  // created in genes_preprocessing branch of CorvoLauncher
                 flatNamesList.add(h5adAnnotationReader("/uns/" + obs + "_names") as ArrayList<String>)
                 flatPvalsList.add(h5adAnnotationReader("/uns/" + obs + "_pvals") as ArrayList<Float>)
                 flatLogfoldchanges.add(h5adAnnotationReader("/uns/" + obs + "_logfoldchanges") as ArrayList<Float>)
-            } catch (e: HDF5SymbolTableException) {
 
+            } catch (e: HDF5SymbolTableException) {
+                println("not encoded")
                 flatNamesList.add(arrayListOf())
                 flatPvalsList.add(arrayListOf())
                 flatLogfoldchanges.add(arrayListOf())
             }
         }
-//        for (i in annotationList){
-//            println(i)
-//        }
-
-//        println(Arrays.toString(reader.string().readArray("obs/FACS.selection/categories")))
-//        println(reader.int8().readArray("obs/FACS.selection/codes")[10].toInt())
-
     }
 
     fun fetchGeneExpression(genes: ArrayList<Int> = arrayListOf()): Triple<ArrayList<String>, ArrayList<FloatArray>, ArrayList<Int>> {
@@ -116,7 +107,7 @@ class AnnotationsIngest(h5adPath: String) {
             }
         }
 
-        val names = genes.map { geneNames[it] } as ArrayList<String>
+        val names = genes.map {feature_name[it]} as ArrayList<String>
 //        println(names)
 
         return Triple(names, expressions, maxList.map { it.toInt() } as ArrayList<Int>)

--- a/src/main/kotlin/graphics/scenery/corvo/AudioDecoder.kt
+++ b/src/main/kotlin/graphics/scenery/corvo/AudioDecoder.kt
@@ -13,6 +13,9 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.json.JSONString
 import org.json.JSONStringer
+import java.util.*
+import kotlin.collections.ArrayList
+import kotlin.reflect.typeOf
 
 
 class AudioDecoder(private val parent: XVisualization, resource: Array<String>) {
@@ -68,12 +71,12 @@ class AudioDecoder(private val parent: XVisualization, resource: Array<String>) 
     private val phonesToSymbols = hashMapOf(
         "dash" to "-",
         "and" to "n"
-    // issue - some gene names are capitalized after the dash!!!!!
+        // issue - some gene names are capitalized after the dash!!!!!
     )
 
     init {
         LibVosk.setLogLevel(LogLevel.DEBUG)
-        rc.setMaxAlternatives(3)
+        rc.setMaxAlternatives(5)
     }
 
     @Throws(IOException::class, UnsupportedAudioFileException::class)
@@ -106,13 +109,13 @@ class AudioDecoder(private val parent: XVisualization, resource: Array<String>) 
                 joinedUtteranceList.add(utterance.joinToString(""))
             }
         }
-
         return joinedUtteranceList
     }
 
     @Throws(IOException::class, UnsupportedAudioFileException::class)
     fun decodeLiveVosk() {
         inProgressFlag = true
+
         var microphone: TargetDataLine
         rc.also { recognizer ->
             try {
@@ -125,40 +128,22 @@ class AudioDecoder(private val parent: XVisualization, resource: Array<String>) 
                 val CHUNK_SIZE = 1024
                 val b = ByteArray(4096)
 
+                val alternatives = arrayListOf<MutableList<String>>()
+
                 while (liveFlag || decodingFlag) {
                     numBytesRead = microphone.read(b, 0, CHUNK_SIZE)
                     out.write(b, 0, numBytesRead)
+
                     if (recognizer.acceptWaveForm(b, numBytesRead)) {
-
-//                        println(recognizer.result.drop(21).dropLast(1))
-
-                        val j = JSONArray(recognizer.result.drop(21).dropLast(1))
-                        println(j.query("/0/text"))
-                        println(j.query("/1/text"))
-                        // can  now fetch n best results. Check all combinations of the word
-
-                        val utterance = recognizer.result.toString().drop(14).dropLast(3).split(" ").toMutableList()
-
-                        for (word in utterance.withIndex()) {
-                            if (phonesToNum.containsKey(word.value)) {
-                                utterance[word.index] = phonesToNum[word.value].toString()
-                            }
-                            if (phonesToSymbols.containsKey(word.value)) {
-                                utterance[word.index] = phonesToSymbols[word.value].toString()
-                            }
+                        JSONArray(recognizer.result.drop(21).dropLast(1)).forEach {
+                            alternatives.add(
+                                (it as JSONObject).query("/text").toString().drop(1).split(" ").toMutableList()
+                            )
                         }
-                        utterance[0] = utterance[0].capitalize()
-
-//                         add to list of requested genes in Xui class
-                        parent.ui.transcription.text = utterance.joinToString(" ")
-                        parent.ui.addDecodedGene(utterance.joinToString(""))
-
-                        // sometimes doesn't stream in partial results, but loads the final result successfully
-                        // load custom selected cells genes using load genes sphere
-                        // make reset last priority
-
+                        // can  now fetch n best results. Check all combinations of the word
+                        // add to list of requested genes in Xui class
+                        parent.ui.transcription.text = alternatives[0].joinToString(" ")
                         decodingFlag = false
-
                     } else {
                         if (recognizer.partialResult[18].toString().isNotBlank()) {
                             decodingFlag = true
@@ -168,8 +153,23 @@ class AudioDecoder(private val parent: XVisualization, resource: Array<String>) 
                     }
                 }
                 microphone.close()
-                inProgressFlag = false
 
+                alternatives.forEach { alt ->
+                    for (word in alt.withIndex()) {
+                        if (phonesToNum.containsKey(word.value)) {
+                            alt[word.index] = phonesToNum[word.value].toString()
+                        }
+                        if (phonesToSymbols.containsKey(word.value)) {
+                            alt[word.index] = phonesToSymbols[word.value].toString()
+                        }
+                    }
+                    alt[0] =
+                        alt[0].replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+                }
+                if (alternatives.isNotEmpty()) {
+                    parent.ui.addDecodedGene(alternatives.map{it.joinToString("")})
+                }
+                inProgressFlag = false
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/src/main/kotlin/graphics/scenery/corvo/PressAndReleaseAudio.kt
+++ b/src/main/kotlin/graphics/scenery/corvo/PressAndReleaseAudio.kt
@@ -14,9 +14,7 @@ class PressAndReleaseAudio(private val parent: XVisualization) : DragBehaviour {
     var noRescale = false
 
     override fun init(x: Int, y: Int) {
-
         thread {
-
             // don't launch decoder if not gracefully shut down
             if (!parent.audioDecoder.inProgressFlag) {
                 parent.ui.micButton.position = Vector3f(0f, 0.018f, 0.02f)
@@ -32,7 +30,6 @@ class PressAndReleaseAudio(private val parent: XVisualization) : DragBehaviour {
                 noRescale = true  // don't give visual signal that recording is in progress to avoid confusion
             }
         }
-
     }
 
     override fun drag(x: Int, y: Int) {}
@@ -46,7 +43,5 @@ class PressAndReleaseAudio(private val parent: XVisualization) : DragBehaviour {
             parent.ui.micButton.scale.z /= 1.3f
             noRescale = false
         }
-
     }
-
 }

--- a/src/main/kotlin/graphics/scenery/corvo/Xui.kt
+++ b/src/main/kotlin/graphics/scenery/corvo/Xui.kt
@@ -17,7 +17,6 @@ class Xui(private val parent: XVisualization) {
     val transcription = TextBoard("SourceSansPro-Light.ttf")
     val micButton = Box(Vector3f(0.015f, 0f, 0.015f))
     val genesToLoad = Mesh()
-    val testLabel = TextBoard("SourceSansPro-Light.ttf")
 
     val requestedGenesNames = ArrayList<String>()
     val requestedGenesIndices = ArrayList<Int>()
@@ -25,10 +24,6 @@ class Xui(private val parent: XVisualization) {
     var geneTagMesh = Mesh()
 
     var categoryLabel = TextBoard("SourceSansPro-Light.ttf")
-
-//    val resetUI = arrayListOf(TextBoard("SourceSansPro-Light.ttf"), Icosphere(0.02f, 3))
-//    val switchSelectionModeUI = arrayListOf(TextBoard("SourceSansPro-Light.ttf"), Icosphere(0.02f, 3))
-//    val loadGenes = arrayListOf(TextBoard("SourceSansPro-Light.ttf"), Icosphere(0.02f, 3))
 
     var switchSelectionModeUIState = 0
 
@@ -46,14 +41,15 @@ class Xui(private val parent: XVisualization) {
         for (mesh in meshList) {
 
             val sphere = Icosphere(scale, 3)
+            sphere.material {
+                diffuse = Vector3f(0.5f)
+                ambient = Vector3f(0.3f)
+                specular = Vector3f(0.1f)
+                roughness = 0.1f
+                metallic = 0.000001f
+            }
+
             val board = TextBoard("SourceSansPro-Light.ttf")
-
-            sphere.material().diffuse = Vector3f(0.5f)
-            sphere.material().ambient = Vector3f(0.3f)
-            sphere.material().specular = Vector3f(0.1f)
-            sphere.material().roughness = 0.1f
-            sphere.material().metallic = 0.000001f
-
             board.spatial().scale = Vector3f(scale)
             board.spatial().rotation.rotateX(-Math.PI.toFloat() / 2f)
             board.transparent = 0
@@ -67,55 +63,58 @@ class Xui(private val parent: XVisualization) {
     }
 
     init {
-//        genesToLoad.visible = true
-        val labelList = arrayListOf(testLabel, transcription, categoryLabel)
+        genesToLoad.visible = true
+        val labelList = arrayListOf(transcription, categoryLabel)
 
         for (label in labelList) {
             label.transparent = 0
             label.fontColor = Vector4f(0f)
             label.backgroundColor = Vector4f(0.7f)
-            label.scale = Vector3f(0.012f)
-            label.rotation.rotateX(-Math.PI.toFloat() / 2f)
+            label.spatial {
+                scale = Vector3f(0.012f)
+                rotation.rotateX(-Math.PI.toFloat() / 2f)
+            }
         }
-
-        testLabel.text = "switch view"
-        testLabel.position = Vector3f(0.005f, 0.009f, 0.017f)
-
         transcription.spatial().position = Vector3f(0.03f, 0.01f, 0.02f)
-
-//        genesToLoad.position = Vector3f(0.03f, 0.01f, 0.03f)
-
         micButton.material().textures["diffuse"] =
             Texture.fromImage(Image.fromResource("volumes/mic_image.jpg", this::class.java))
-        micButton.material().metallic = 0.3f
-        micButton.material().roughness = 0.9f
-        micButton.material().diffuse = Vector3f(0.5f)
+        micButton.material {
+            metallic = 0.3f
+            roughness = 0.9f
+            diffuse = Vector3f(0.5f)
+        }
         micButton.spatial().position = Vector3f(0f, 0.01f, 0.02f)
 
         // define features of category label (display selected category on controller)
-        categoryLabel.scale = Vector3f(scale)
-        categoryLabel.position = Vector3f(0.1f, 0f, 0f)
+        categoryLabel.spatial {
+            scale = Vector3f(scale)
+            position = Vector3f(0.1f, 0f, 0f)
+        }
 
         dispMainUI()
     }
 
-    fun dispMainUI() {
-        (resetUI.children.first() as TextBoard).text = "reset"
-        (switchSelectionModeUI.children.first() as TextBoard).text = "switch selector"
-        (loadGenesUI.children.first() as TextBoard).text = "load genes"
+    private fun dispMainUI() {
+        val resetUIText = resetUI.children.first() as TextBoard
+        val switchSelectionModeUIText = switchSelectionModeUI.children.first() as TextBoard
+        val loadGenesUIText = loadGenesUI.children.first() as TextBoard
 
-        resetUI.children.first().position =
+        resetUIText.text = "reset"
+        switchSelectionModeUIText.text = "switch selector"
+        loadGenesUIText.text = "load genes"
+
+        resetUIText.spatial().position =
             Vector3f(-triSize + (scale / sqrt(2f)), -0.025f, triSize - triOffset - (scale / sqrt(2f)))
-        resetUI.children.last().position = Vector3f(-triSize, -0.025f, triSize - triOffset)
+        (resetUI.children.last() as Icosphere).spatial().position = Vector3f(-triSize, -0.025f, triSize - triOffset)
 
-        switchSelectionModeUI.children.first().position =
+        switchSelectionModeUIText.spatial().position =
             Vector3f(triSize + (scale / sqrt(2f)), -0.025f, triSize - triOffset - (scale / sqrt(2f)))
-        switchSelectionModeUI.children.last().position = Vector3f(triSize, -0.025f, triSize - triOffset)
+        (switchSelectionModeUI.children.last() as Icosphere).spatial().position =
+            Vector3f(triSize, -0.025f, triSize - triOffset)
 
-        loadGenesUI.children.first().position =
+        loadGenesUIText.spatial().position =
             Vector3f((scale / sqrt(2f)), -0.025f, -triSize - triOffset - (scale / sqrt(2f)))
-        loadGenesUI.children.last().position = Vector3f(0f, -0.025f, -triSize - triOffset)
-
+        (loadGenesUI.children.last() as Icosphere).spatial().position = Vector3f(0f, -0.025f, -triSize - triOffset)
     }
 
     /**
@@ -125,7 +124,7 @@ class Xui(private val parent: XVisualization) {
     fun dispGenes(selectedCluster: Int) {
         if (selectedCluster != -1 && !currentlyFetching) {
             currentlyFetching = true
-            val geneIndices = ArrayList<Int>()
+//            val geneIndices = ArrayList<Int>()
 
             parent.hmd.getTrackedDevices(TrackedDeviceType.Controller).forEach { device ->
                 if (device.value.role == TrackerRole.LeftHand) {
@@ -139,44 +138,11 @@ class Xui(private val parent: XVisualization) {
             categoryLabel.text = parent.plot.annFetcher.categoryNames[annotationPicker][selectedCluster]
 
             val clusterData = parent.plot.annFetcher.precompGenesReader(annotationPicker, selectedCluster)
+            val geneIDs = clusterData.second.first
+            val geneIndices = if (geneIDs.isNotEmpty()) geneIDs[0].map {
+                parent.plot.annFetcher.feature_id.indexOf(it)
+            } as ArrayList<Int> else arrayListOf()
 
-            if (clusterData.second.first.isNotEmpty()) {
-                val backC =
-                    ((selectedCluster.toFloat()) / (clusterData.first.toFloat() - 1)) * 0.99f
-
-                for (i in 0 until clusterData.second.first[0].size) {
-
-                    geneIndices.add(parent.plot.annFetcher.geneNames.indexOf(clusterData.second.first[0][i]))
-
-                    val geneTag = TextBoard("SourceSansPro-Light.ttf")
-                    geneTag.text =
-                        clusterData.second.first[0][i] +
-                                ", p: " + clusterData.second.second[0][i].toString() +
-                                ", f.c.: " + clusterData.second.third[0][i].toString()
-
-                    geneTag.scale = Vector3f(scale)
-                    geneTag.position = Vector3f(
-                        0.1f,
-                        0f,
-                        (i * scale) + (scale * 1.15f)
-                    )
-                    geneTag.rotation.rotateX(-Math.PI.toFloat() / 2f)
-                    geneTag.transparent = 0
-                    geneTag.fontColor = Vector4f(0f)
-                    geneTag.backgroundColor = parent.plot.rgbColorSpectrum.sample(backC)
-
-                    geneTagMesh.addChild(geneTag)
-                }
-            }
-
-            (geneTagMesh.children.first() as TextBoard).fontFamily = "SourceSansPro-Semibold.ttf"
-
-            parent.hmd.getTrackedDevices(TrackedDeviceType.Controller).forEach { device ->
-                if (device.value.role == TrackerRole.LeftHand) {
-                    device.value.model?.addChild(geneTagMesh)
-                    device.value.model?.addChild(categoryLabel)
-                }
-            }
             ////////////////////////////////////////
 
             val buffer = parent.plot.annFetcher.fetchGeneExpression(geneIndices)
@@ -192,31 +158,77 @@ class Xui(private val parent: XVisualization) {
             parent.maxTick.text = maxExprList[genePicker].toString()
 
             ///////////////////////////////////////
+
+            if (clusterData.second.first.isNotEmpty()) {
+                val backC = ((selectedCluster.toFloat()) / (clusterData.first.toFloat() - 1)) * 0.99f
+                clusterData.second.first[0].withIndex().forEach {
+                    val geneTag = TextBoard("SourceSansPro-Light.ttf")
+                    geneTag.text =
+                        geneNames[it.index] +
+                                ", p: " + clusterData.second.second[0][it.index].toString() +
+                                ", f.c.: " + clusterData.second.third[0][it.index].toString()
+                    geneTag.spatial().scale = Vector3f(scale)
+                    geneTag.spatial().rotation.rotateX(-Math.PI.toFloat() / 2f)
+                    geneTag.spatial().position = Vector3f(
+                        0.1f,
+                        0f,
+                        (it.index * scale) + (scale * 1.15f)
+                    )
+                    geneTag.transparent = 0
+                    geneTag.fontColor = Vector4f(0f)
+                    geneTag.backgroundColor = parent.plot.rgbColorSpectrum.sample(backC)
+
+                    geneTagMesh.addChild(geneTag)
+                }
+                (geneTagMesh.children.first() as TextBoard).fontFamily = "SourceSansPro-Semibold.ttf"
+
+                parent.hmd.getTrackedDevices(TrackedDeviceType.Controller).forEach { device ->
+                    if (device.value.role == TrackerRole.LeftHand) {
+                        device.value.model?.addChild(geneTagMesh)
+                        device.value.model?.addChild(categoryLabel)
+                    }
+                }
+            }
             currentlyFetching = false
         }
     }
-
-    fun addDecodedGene(name: String) {
-        requestedGenesNames.add(name)
-
+    /**
+     * addDecodedGene takes alternatives returned by LibVosk and checks if they match a known gene.
+     * If a match is found, it is added to the XUi property requestedGenesIndices to be loaded on user request.
+     * If not, the first alternative is loaded on a red instead of green label.
+     */
+    fun addDecodedGene(alternatives: List<String>) {
+        // doesn't seem to pick up the first letter or do a good job of decoding.
         val geneLabel = TextBoard("SourceSansPro-Light.ttf")
         geneLabel.visible = true
         geneLabel.transparent = 0
         geneLabel.fontColor = Vector4f(0f)
-        geneLabel.scale = Vector3f(0.012f)
-        geneLabel.rotation.rotateX(-Math.PI.toFloat() / 2f)
-        geneLabel.text = name
-
-        val geneIndex = parent.plot.annFetcher.geneNames.indexOf(name)
-
-        if (geneIndex != -1) {
-            geneLabel.backgroundColor = Vector3f(0.73f, 1.00f, 0.60f).xyzw()
-            requestedGenesIndices.add(geneIndex)
-        } else {
-            geneLabel.backgroundColor = Vector3f(1.00f, 0.73f, 0.60f).xyzw()
+        geneLabel.spatial {
+            scale = Vector3f(0.012f)
+            rotation.rotateX(-Math.PI.toFloat() / 2f)
         }
 
-        geneLabel.position = Vector3f(0.03f, 0.01f, 0.025f + (0.012f * (requestedGenesNames.size)))
+        val checks = alternatives.map { alt ->
+            parent.plot.annFetcher.feature_name.indexOf(alt)
+        } as ArrayList<Int>
+
+        geneLabel.backgroundColor = Vector3f(1.00f, 0.73f, 0.60f).xyzw() //start red and turn green if found
+
+        var chosenAlternative = ""
+        for (result in checks.withIndex()) {
+            if (result.value != -1) {
+                chosenAlternative = alternatives[result.index]
+                geneLabel.backgroundColor = Vector3f(0.73f, 1.00f, 0.60f).xyzw()
+                requestedGenesIndices.add(result.value)
+                break
+            } else {
+                chosenAlternative = alternatives[0]
+            }
+        }
+        geneLabel.text = chosenAlternative
+        requestedGenesNames.add(chosenAlternative)
+
+        geneLabel.spatial().position = Vector3f(0.03f, 0.01f, 0.025f + (0.012f * (requestedGenesNames.size)))
         genesToLoad.addChild(geneLabel)
     }
 


### PR DESCRIPTION
- scanPy uses feature_id to name most differentially expressed genes (do not exist in feature_name). Now find index of top precomputed genes on run and use index to find proper name.
- refactor of name fetching in Xui.dispGenes to avoid duplicate tasks
- intersection with instances does not work - work around now adds child sphere and check intersection with .children.first()
- Prevent multi-second load of precomputed genes by rounding p values in CorvoLauncher
- fixed issue where LibVosk was returning between 0 and n alternatives, but the UI expected 1.
- adapted speech to text gene search to search up to 5 most confident alternatives.